### PR TITLE
Force installation of <v2.0.0 paho-mqtt

### DIFF
--- a/en/202305/how-to-use-mqtt-in-python.md
+++ b/en/202305/how-to-use-mqtt-in-python.md
@@ -39,8 +39,10 @@ Python 3.6.7
 Install the paho-mqtt library using Pip.
 
 ```cmake
-pip3 install paho-mqtt
+pip3 install paho-mqtt<2.0.0
 ```
+
+(Version 2.0.0 of the library was released in Feburary 2024; the new version contains breaking changes so the above installs v1, which is compatible with this tutorial).
 
 >If you need help installing Pip, please refer to the official documentation at [https://pip.pypa.io/en/stable/installation/](https://pip.pypa.io/en/stable/installation/). This resource provides detailed instructions for installing Pip on different operating systems and environments.
 

--- a/en/202305/how-to-use-mqtt-in-python.md
+++ b/en/202305/how-to-use-mqtt-in-python.md
@@ -39,7 +39,7 @@ Python 3.6.7
 Install the paho-mqtt library using Pip.
 
 ```cmake
-pip3 install paho-mqtt<2.0.0
+pip3 install "paho-mqtt<2.0.0"
 ```
 
 (Version 2.0.0 of the library was released in Feburary 2024; the new version contains breaking changes so the above installs v1, which is compatible with this tutorial).


### PR DESCRIPTION
v2 of the paho-mqtt introduces breaking changes which are likely to confuse readers. Probably worth specifying v1 until a new tutorial is released.