### PR TITLE
Replace full-width quotation marks with half-width ones 

### DIFF
--- a/en/202403/how-to-publish-and-receive-protobuf-messages-within-mqtt.md
+++ b/en/202403/how-to-publish-and-receive-protobuf-messages-within-mqtt.md
@@ -43,7 +43,7 @@ The MQTTX desktop client offers users a more efficient and personalized experien
    Here’s a commonly used proto format in the IoT:
 
    ```protobuf
-   syntax = “proto3”;
+   syntax = "proto3";
    
    package IoT;
    


### PR DESCRIPTION
The previous example protobuf definition would case: Error: illegal token '”proto3“' (line 1)