### PR TITLE
docs: fix global tdengine cloud url

### DIFF
--- a/en/202505/emqx-cloud-and-tdengine-cloud.md
+++ b/en/202505/emqx-cloud-and-tdengine-cloud.md
@@ -35,7 +35,7 @@ In the next section, we’ll walk you through how to use this connector to strea
 
 ### Step 1: TDengine Cloud Preparations 
 
-1. Log in to the TDengine Cloud console: [https://cloud.taosdata.com](https://cloud.taosdata.xn--com-9o0a./)
+1. Log in to the TDengine Cloud console: [https://cloud.tdengine.com](https://cloud.tdengine.com)
 
 2. Create and deploy a TDengine Cloud service instance. 
 


### PR DESCRIPTION
TDengine Cloud uses cloud.taosdata.com as the URL for the Chinese market but cloud.tdengine.com for the global market.